### PR TITLE
Add assign policy command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AssignPolicyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignPolicyCommand.java
@@ -1,0 +1,111 @@
+package seedu.address.logic.commands;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.*;
+import seedu.address.model.policy.*;
+import seedu.address.model.tag.Tag;
+
+import java.util.List;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+/**
+ * Command to assign a new policy to a person.
+ */
+public class AssignPolicyCommand {
+
+    public static final String COMMAND_WORD = "assignpolicy";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Assigns the policy (identified by the first index) "
+            + "to a person (identified by the second index).\n"
+            + "Parameters: INDEX_POLICY (must be a positive integer) "
+            + "INDEX_PERSON (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1 1 ";
+
+    public static final String MESSAGE_ASSIGN_POLICY_SUCCESS = "Assigned Policy: %1$s to Person: %2$s";
+    public static final String MESSAGE_ALREADY_ASSIGNED = "Person already has the policy.";
+
+
+    private final Index policyIndex;
+    private final Index personIndex;
+
+    /**
+     * @param policyIndex Index of the policy to assign
+     * @param personIndex Index of the person to be assigned
+     */
+    public AssignPolicyCommand(Index policyIndex, Index personIndex) {
+        requireNonNull(policyIndex);
+        requireNonNull(personIndex);
+
+        this.policyIndex = policyIndex;
+        this.personIndex = personIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownPersonList = model.getFilteredPersonList();
+        List<Policy> lastShownPolicyList = model.getFilteredPolicyList();
+
+        if (policyIndex.getZeroBased() >= lastShownPolicyList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_POLICY_DISPLAYED_INDEX);
+        }
+        if (personIndex.getZeroBased() >= lastShownPersonList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Policy policy = lastShownPolicyList.get(policyIndex.getZeroBased());
+        Person person = lastShownPersonList.get(personIndex.getZeroBased());
+
+        if (person.hasPolicy(policy)) {
+            throw new CommandException(MESSAGE_ALREADY_ASSIGNED);
+        }
+
+        Person assignedPerson = createAssignedPerson(person, policy);
+        model.setPerson(person, assignedPerson);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        return new CommandResult(String.format(MESSAGE_ASSIGN_POLICY_SUCCESS, policy, assignedPerson));
+    }
+
+    /**
+     * Creates and returns a {@code Policy} with the details of {@code policyToCopy}.
+     */
+    private static Policy copyPolicy(Policy policyToCopy) {
+        requireNonNull(policyToCopy);
+
+        PolicyName name = policyToCopy.getName();
+        Description description = policyToCopy.getDescription();
+        Coverage coverage = policyToCopy.getCoverage();
+        Price price = policyToCopy.getPrice();
+        StartAge startAge = policyToCopy.getStartAge();
+        EndAge endAge = policyToCopy.getEndAge();
+        Set<Tag> criteria = policyToCopy.getCriteria();
+        Set<Tag> tags = policyToCopy.getTags();
+
+        return new Policy(name, description, coverage, price, startAge, endAge, criteria, tags);
+    }
+
+    /**
+     * Creates a returns a {@code Person} with the details of {@code person}
+     * with an additional policy {@code policy}.
+     */
+    private static Person createAssignedPerson(Person person, Policy policy) {
+        Name name = person.getName();
+        Nric nric = person.getNric();
+        Phone phone = person.getPhone();
+        Email email = person.getEmail();
+        Address address = person.getAddress();
+        DateOfBirth dateOfBirth = person.getDateOfBirth();
+        Set<Policy> updatedPolicies = person.getPolicies();
+        updatedPolicies.add(copyPolicy(policy));
+        Set<Tag> tags = person.getTags();
+
+        return new Person(name, nric, phone, email, address, dateOfBirth, updatedPolicies, tags);
+    }
+
+}

--- a/src/main/java/seedu/address/logic/commands/AssignPolicyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignPolicyCommand.java
@@ -1,18 +1,34 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PERSON_INDEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_POLICY_INDEX;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.person.*;
-import seedu.address.model.policy.*;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.DateOfBirth;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Nric;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+
+import seedu.address.model.policy.Coverage;
+import seedu.address.model.policy.Description;
+import seedu.address.model.policy.EndAge;
+import seedu.address.model.policy.Policy;
+import seedu.address.model.policy.PolicyName;
+import seedu.address.model.policy.Price;
+import seedu.address.model.policy.StartAge;
 import seedu.address.model.tag.Tag;
-
-import java.util.List;
-import java.util.Set;
-
-import static java.util.Objects.requireNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 /**
  * Command to assign a new policy to a person.
@@ -21,14 +37,17 @@ public class AssignPolicyCommand extends Command {
 
     public static final String COMMAND_WORD = "assignpolicy";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Assigns the policy (identified by the first index) "
-            + "to a person (identified by the second index).\n"
-            + "Parameters: INDEX_POLICY (must be a positive integer) "
-            + "INDEX_PERSON (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " 1 1 ";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Assigns the policy to a person.\n"
+            + "Parameters: "
+            + PREFIX_POLICY_INDEX + "POLICY INDEX "
+            + PREFIX_PERSON_INDEX + "PERSON INDEX\n"
+            + "Example: "
+            + COMMAND_WORD + " "
+            + PREFIX_POLICY_INDEX + "1 "
+            + PREFIX_PERSON_INDEX + "1";
 
     public static final String MESSAGE_ASSIGN_POLICY_SUCCESS = "Assigned Policy: %1$s to Person: %2$s";
-    public static final String MESSAGE_ALREADY_ASSIGNED = "Person already has the policy.";
+    public static final String MESSAGE_ALREADY_ASSIGNED = "Person: %1$s already has the Policy: %2$s.";
 
 
     private final Index policyIndex;
@@ -63,14 +82,16 @@ public class AssignPolicyCommand extends Command {
         Person person = lastShownPersonList.get(personIndex.getZeroBased());
 
         if (person.hasPolicy(policy)) {
-            throw new CommandException(MESSAGE_ALREADY_ASSIGNED);
+            throw new CommandException(String.format(MESSAGE_ALREADY_ASSIGNED,
+                    person.getName(), policy.getName()));
         }
 
         Person assignedPerson = createAssignedPerson(person, policy);
 
         model.setPerson(person, assignedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(String.format(MESSAGE_ASSIGN_POLICY_SUCCESS, policy, assignedPerson));
+        return new CommandResult(String.format(MESSAGE_ASSIGN_POLICY_SUCCESS,
+                policy.getName(), assignedPerson.getName()));
     }
 
     /**
@@ -102,7 +123,7 @@ public class AssignPolicyCommand extends Command {
         Email email = person.getEmail();
         Address address = person.getAddress();
         DateOfBirth dateOfBirth = person.getDateOfBirth();
-        Set<Policy> updatedPolicies = person.getPolicies();
+        Set<Policy> updatedPolicies = new HashSet<Policy>(person.getPolicies());
         updatedPolicies.add(copyPolicy(policy));
         Set<Tag> tags = person.getTags();
 

--- a/src/main/java/seedu/address/logic/commands/AssignPolicyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignPolicyCommand.java
@@ -17,7 +17,7 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 /**
  * Command to assign a new policy to a person.
  */
-public class AssignPolicyCommand {
+public class AssignPolicyCommand extends Command {
 
     public static final String COMMAND_WORD = "assignpolicy";
 
@@ -67,6 +67,7 @@ public class AssignPolicyCommand {
         }
 
         Person assignedPerson = createAssignedPerson(person, policy);
+
         model.setPerson(person, assignedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_ASSIGN_POLICY_SUCCESS, policy, assignedPerson));
@@ -106,6 +107,24 @@ public class AssignPolicyCommand {
         Set<Tag> tags = person.getTags();
 
         return new Person(name, nric, phone, email, address, dateOfBirth, updatedPolicies, tags);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof AssignPolicyCommand)) {
+            return false;
+        }
+
+        // state check
+        AssignPolicyCommand e = (AssignPolicyCommand) other;
+        return personIndex.equals(e.personIndex)
+                && policyIndex.equals(e.policyIndex);
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -8,6 +8,7 @@ import java.util.regex.Pattern;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AddPolicyCommand;
+import seedu.address.logic.commands.AssignPolicyCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
@@ -66,10 +67,10 @@ public class AddressBookParser {
         case DeletePolicyCommand.COMMAND_WORD:
             return new DeletePolicyCommandParser().parse(arguments);
 
-        /*
         case AssignPolicyCommand.COMMAND_WORD:
             return new AssignPolicyCommandParser().parse(arguments);
 
+        /*
         case UnassignPolicyCommand.COMMAND_WORD:
             return new UnassignPolicyCommandParser().parse(arguments);
 

--- a/src/main/java/seedu/address/logic/parser/AssignPolicyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AssignPolicyCommandParser.java
@@ -1,0 +1,55 @@
+package seedu.address.logic.parser;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.AssignPolicyCommand;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PERSON_INDEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_POLICY_INDEX;
+
+/**
+ * Parses input arguments and creates a new AssignPolicyCommand object
+ */
+public class AssignPolicyCommandParser implements Parser<AssignPolicyCommand> {
+
+    /**
+     *
+     * Parses the given {@code String} of arguments in the context of the AssignPolicyCommand
+     * and returns an AssignPolicyCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public AssignPolicyCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_POLICY_INDEX, PREFIX_PERSON_INDEX);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_POLICY_INDEX, PREFIX_PERSON_INDEX)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AssignPolicyCommand.MESSAGE_USAGE));
+        }
+
+        Index personIndex = null;
+        Index policyIndex = null;
+
+        try {
+            policyIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_POLICY_INDEX).get());
+            personIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_PERSON_INDEX).get());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AssignPolicyCommand.MESSAGE_USAGE), pe);
+        }
+
+        return new AssignPolicyCommand(policyIndex, personIndex);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AssignPolicyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AssignPolicyCommandParser.java
@@ -1,16 +1,15 @@
 package seedu.address.logic.parser;
 
-import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.AssignPolicyCommand;
-import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.logic.parser.exceptions.ParseException;
-
-import java.util.stream.Stream;
-
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PERSON_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_POLICY_INDEX;
+
+import java.util.stream.Stream;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.AssignPolicyCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
  * Parses input arguments and creates a new AssignPolicyCommand object
@@ -39,7 +38,8 @@ public class AssignPolicyCommandParser implements Parser<AssignPolicyCommand> {
             policyIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_POLICY_INDEX).get());
             personIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_PERSON_INDEX).get());
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AssignPolicyCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    AssignPolicyCommand.MESSAGE_USAGE), pe);
         }
 
         return new AssignPolicyCommand(policyIndex, personIndex);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -17,8 +17,8 @@ public class CliSyntax {
     public static final Prefix PREFIX_TAG = new Prefix("t/");
 
     // Policy prefix
-    public static final Prefix PREFIX_DESCRIPTION = new Prefix ("d/");
-    public static final Prefix PREFIX_COVERAGE = new Prefix ("c/");
+    public static final Prefix PREFIX_DESCRIPTION = new Prefix("d/");
+    public static final Prefix PREFIX_COVERAGE = new Prefix("c/");
     public static final Prefix PREFIX_DAYS = new Prefix("days/");
     public static final Prefix PREFIX_MONTHS = new Prefix("months/");
     public static final Prefix PREFIX_YEARS = new Prefix("years/");
@@ -26,6 +26,10 @@ public class CliSyntax {
     public static final Prefix PREFIX_START_AGE = new Prefix ("sa/");
     public static final Prefix PREFIX_END_AGE = new Prefix("ea/");
     public static final Prefix PREFIX_CRITERIA = new Prefix("cr/");
+
+    // Prefixes for assign/unassign policy commands
+    public static final Prefix PREFIX_POLICY_INDEX = new Prefix("polindex/");
+    public static final Prefix PREFIX_PERSON_INDEX = new Prefix("perindex/");
 
     public static final Prefix PREFIX_MERGE = new Prefix("m/");
 }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -98,6 +98,14 @@ public class Person {
     }
 
     /**
+     * Returns true if the person has the policy in the policies list.
+     * Used as a check during the Assign Policy Command.
+     */
+    public boolean hasPolicy(Policy policy) {
+        return this.policies.contains((Policy) policy);
+    }
+
+    /**
      * Returns true if both persons have the same identity and data fields.
      * This defines a stronger notion of equality between two persons.
      */

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -69,7 +69,7 @@ public class Person {
     }
 
     /**
-     * Returns an immutable tag set, which throws {@code UnsupportedOperationException}
+     * Returns an immutable policy set, which throws {@code UnsupportedOperationException}
      * if modification is attempted.
      */
     public Set<Policy> getPolicies() {


### PR DESCRIPTION
Add an `assignpolicy` command to Insurelytics.
Format: `assignpolicy polindex/INTEGER perindex/INTEGER`

The command obtains the relevant policy from the last shown policy list, and copies it into the policy list for the concerned person.