### PR TITLE
Modify assign/unassign policy commands and add tests

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -241,7 +241,7 @@ Finds all people eligible for the 1st policy in the displayed policy list.
 === Adding policies to a person : `assignpolicy`
 
 Assigns a policy to the person at the specified index. +
-Format: `assignpolicy perindex/INDEX polindex/INDEX`
+Format: `assignpolicy INDEX pol/POLICY NAME`
 
 ****
 * Adds the policies to the person at the specified `INDEX`.
@@ -258,7 +258,7 @@ Examples:
 `assignpolicy perindex/2 polindex/2` +
 Assigns the 'Senior Care' (the second policy in the list) policy to the 2nd person in the list of people.
 * `find Betsy` +
-`assignpolicy perindex/1 polindex/1` +
+`assignpolicy 1 pol/Accident Insurance` +
 Assigns the 'Accident Insurance' (the first policy in the list) policy to the 1st person in the results of the `find` command.
 
 === Adding tags to a person : `addtag`
@@ -368,7 +368,7 @@ Deletes the 1st policy in the results of the `findpolicy` command.
 === Deleting policies from a person : `unassignpolicy`
 
 Removes a policy from the person at the specified index. +
-Format: `unassignpolicy perindex/INDEX polindex/INDEX`
+Format: `unassignpolicy INDEX pol/POLICY NAME`
 
 ****
 * Removes the policies to the person at the specified `INDEX`.
@@ -381,11 +381,11 @@ Format: `unassignpolicy perindex/INDEX polindex/INDEX`
 Examples:
 
 * `listpeople` +
-`unassignpolicy perindex/2 polindex/3` +
-Removes the 3rd policy in the absolute list from the 2nd person in the displayed list of people.
+`unassignpolicy 2 pol/Accident Insurance` +
+Removes the policy 'Accident Insurance' in the absolute list from the 2nd person in the displayed list of people.
 * `find Betsy` +
-`unassignpolicy perindex/1 polindex/4` +
-Removes the 4th policy in the absolute list from the 1st person in the results of the `find` command.
+`unassignpolicy 1 pol/Health insurance` +
+Removes the policy 'Health Insurance' in the absolute list from the 1st person in the results of the `find` command.
 
 === Deleting tags from a person : `deletetag`
 
@@ -821,8 +821,8 @@ e.g. `findpolicy senior`
 e.g. `findtagpeople smoker diabetic`
 * *Find policy by tags*: `findtagpolicy TAG [MORE_TAGS]` +
 e.g. `findtagpolicy accident life`
-* *Assign Policy* : `assignpolicy perindex/INDEX polindex/INDEX` +
-e.g. `assignpolicy perindex/2 polindex/2`
+* *Assign Policy* : `assignpolicy INDEX pol/POLICY NAME` +
+e.g. `assignpolicy 2 pol/Health insurance`
 * *Add Tag To Person* : `addtag INDEX t/TAG [MORE_TAGS]` +
 e.g. `addtag 3 t/high_priority`
 * *Add Tag To Policy* : `addpolicytag INDEX t/TAG [MORE_TAGS]` +
@@ -831,8 +831,8 @@ e.g. `addpolicytag 2 t/lifeinsurance`
 e.g. `delete 3`
 * *Delete Policy* : `deletepolicy INDEX` +
 e.g. `deletepolicy 3`
-* *Unassign Policy* : `unassignpolicy INDEX polindex/INDEX` +
-e.g. `unassignpolicy perindex/2 pol/2`
+* *Unassign Policy* : `unassignpolicy INDEX pol/POLICY NAME` +
+e.g. `unassignpolicy 2 pol/Health insurance`
 * *Delete Tag From Person* : `deletetag INDEX t/TAG [MORE_TAGS]` +
 e.g. `deletetag 3 t/high_priority`
 * *Delete Tag From Policy* : `deletepolicytag INDEX t/TAG [MORE_TAGS]` +

--- a/src/main/java/seedu/address/commons/util/PersonBuilder.java
+++ b/src/main/java/seedu/address/commons/util/PersonBuilder.java
@@ -117,10 +117,9 @@ public class PersonBuilder {
     }
 
     /**
-     * Parses the {@code policies} into a {@code Set<Tag>} and set it to the {@code Person} that we are building.
+     * Parses the {@code policies} into a {@code Set<Policy>} and set it to the {@code Person} that we are building.
      */
     public PersonBuilder withPolicies(Policy ... policies) {
-<<<<<<< HEAD:src/main/java/seedu/address/commons/util/PersonBuilder.java
         this.policies = new HashSet<>(Arrays.asList(policies));
         return this;
     }
@@ -134,13 +133,10 @@ public class PersonBuilder {
     }
 
     /**
-     * Parses the {@code policies} into a {@code Set<Tag>} and removes it from the {@code Person} that we are building.
+     * Parses the {@code policies} into a {@code Set<Policy>} removes it from the policies of the {@code Person} that we are building.
      */
     public PersonBuilder removePolicies(Policy ... policies) {
         this.policies.removeAll(Arrays.asList(policies));
-=======
-        this.policies.addAll(Arrays.asList(policies));
->>>>>>> Add AssignPolicyCommand tests:src/test/java/seedu/address/testutil/PersonBuilder.java
         return this;
     }
 

--- a/src/main/java/seedu/address/commons/util/PersonBuilder.java
+++ b/src/main/java/seedu/address/commons/util/PersonBuilder.java
@@ -133,7 +133,8 @@ public class PersonBuilder {
     }
 
     /**
-     * Parses the {@code policies} into a {@code Set<Policy>} removes it from the policies of the {@code Person} that we are building.
+     * Parses the {@code policies} into a {@code Set<Policy>} removes it from the policies of the {@code Person}
+     * that we are building.
      */
     public PersonBuilder removePolicies(Policy ... policies) {
         this.policies.removeAll(Arrays.asList(policies));

--- a/src/main/java/seedu/address/commons/util/PersonBuilder.java
+++ b/src/main/java/seedu/address/commons/util/PersonBuilder.java
@@ -120,6 +120,7 @@ public class PersonBuilder {
      * Parses the {@code policies} into a {@code Set<Tag>} and set it to the {@code Person} that we are building.
      */
     public PersonBuilder withPolicies(Policy ... policies) {
+<<<<<<< HEAD:src/main/java/seedu/address/commons/util/PersonBuilder.java
         this.policies = new HashSet<>(Arrays.asList(policies));
         return this;
     }
@@ -137,6 +138,9 @@ public class PersonBuilder {
      */
     public PersonBuilder removePolicies(Policy ... policies) {
         this.policies.removeAll(Arrays.asList(policies));
+=======
+        this.policies.addAll(Arrays.asList(policies));
+>>>>>>> Add AssignPolicyCommand tests:src/test/java/seedu/address/testutil/PersonBuilder.java
         return this;
     }
 

--- a/src/main/java/seedu/address/logic/commands/AssignPolicyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignPolicyCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PERSON_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_POLICY_INDEX;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_POLICIES;
 
 import java.util.List;
 
@@ -77,6 +78,7 @@ public class AssignPolicyCommand extends Command {
 
         model.setPerson(person, assignedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredPolicyList(PREDICATE_SHOW_ALL_POLICIES);
         return new CommandResult(String.format(MESSAGE_ASSIGN_POLICY_SUCCESS,
                 policy.getName(), assignedPerson.getName()));
     }

--- a/src/main/java/seedu/address/logic/commands/AssignPolicyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignPolicyCommand.java
@@ -26,7 +26,7 @@ public class AssignPolicyCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Assigns the policy to a person.\n"
             + "Parameters: "
-            + "INDEX (must be a positive integer)"
+            + "INDEX (must be a positive integer) "
             + PREFIX_POLICY + "POLICY NAME\n"
             + "Example: "
             + COMMAND_WORD + " 1 "

--- a/src/main/java/seedu/address/logic/commands/AssignPolicyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignPolicyCommand.java
@@ -34,7 +34,7 @@ public class AssignPolicyCommand extends Command {
 
     public static final String MESSAGE_ASSIGN_POLICY_SUCCESS = "Assigned Policy: %1$s to Person: %2$s";
     public static final String MESSAGE_ALREADY_ASSIGNED = "Person: %1$s already has the Policy: %2$s.";
-    public static final String MESSAGE_POLICY_NOT_FOUND = "Policy: %1$s not found in address book.";
+    public static final String MESSAGE_POLICY_NOT_FOUND = "Policy: %1$s not found in the list of policies.";
 
     private final PolicyName policyName;
     private final Index personIndex;
@@ -75,8 +75,6 @@ public class AssignPolicyCommand extends Command {
         Person assignedPerson = new PersonBuilder(person).addPolicies(copyPolicy).build();
 
         model.setPerson(person, assignedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        model.updateFilteredPolicyList(PREDICATE_SHOW_ALL_POLICIES);
         return new CommandResult(String.format(MESSAGE_ASSIGN_POLICY_SUCCESS,
                 policy.getName(), assignedPerson.getName()));
     }

--- a/src/main/java/seedu/address/logic/commands/AssignPolicyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignPolicyCommand.java
@@ -1,8 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PERSON_INDEX;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_POLICY_INDEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_POLICY;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_POLICIES;
 
@@ -16,6 +15,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 import seedu.address.model.policy.Policy;
+import seedu.address.model.policy.PolicyName;
 
 /**
  * Command to assign a new policy to a person.
@@ -26,51 +26,49 @@ public class AssignPolicyCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Assigns the policy to a person.\n"
             + "Parameters: "
-            + PREFIX_POLICY_INDEX + "POLICY INDEX "
-            + PREFIX_PERSON_INDEX + "PERSON INDEX\n"
+            + "INDEX (must be a positive integer)"
+            + PREFIX_POLICY + "POLICY NAME\n"
             + "Example: "
-            + COMMAND_WORD + " "
-            + PREFIX_POLICY_INDEX + "1 "
-            + PREFIX_PERSON_INDEX + "1";
+            + COMMAND_WORD + " 1 "
+            + PREFIX_POLICY + "health insurance";
 
     public static final String MESSAGE_ASSIGN_POLICY_SUCCESS = "Assigned Policy: %1$s to Person: %2$s";
     public static final String MESSAGE_ALREADY_ASSIGNED = "Person: %1$s already has the Policy: %2$s.";
+    public static final String MESSAGE_POLICY_NOT_FOUND = "Policy: %1$s not found in address book.";
 
-
-    private final Index policyIndex;
+    private final PolicyName policyName;
     private final Index personIndex;
 
     /**
-     * @param policyIndex Index of the policy to assign
      * @param personIndex Index of the person to be assigned
+     * @param policyName Name of the policy to assign
      */
-    public AssignPolicyCommand(Index policyIndex, Index personIndex) {
-        requireNonNull(policyIndex);
+    public AssignPolicyCommand(Index personIndex, PolicyName policyName) {
+        requireNonNull(policyName);
         requireNonNull(personIndex);
 
-        this.policyIndex = policyIndex;
         this.personIndex = personIndex;
+        this.policyName = policyName;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Person> lastShownPersonList = model.getFilteredPersonList();
-        List<Policy> lastShownPolicyList = model.getFilteredPolicyList();
 
-        if (policyIndex.getZeroBased() >= lastShownPolicyList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_POLICY_DISPLAYED_INDEX);
-        }
+
         if (personIndex.getZeroBased() >= lastShownPersonList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
+        if (!model.hasPolicyWithName(policyName)) {
+            throw new CommandException(String.format(MESSAGE_POLICY_NOT_FOUND, policyName));
+        }
 
-        Policy policy = lastShownPolicyList.get(policyIndex.getZeroBased());
+        Policy policy = model.getPolicyWithName(policyName);
         Person person = lastShownPersonList.get(personIndex.getZeroBased());
 
         if (person.hasPolicy(policy)) {
-            throw new CommandException(String.format(MESSAGE_ALREADY_ASSIGNED,
-                    person.getName(), policy.getName()));
+            throw new CommandException(String.format(MESSAGE_ALREADY_ASSIGNED, person.getName(), policy.getName()));
         }
 
         Policy copyPolicy = new PolicyBuilder(policy).build();
@@ -98,7 +96,7 @@ public class AssignPolicyCommand extends Command {
         // state check
         AssignPolicyCommand e = (AssignPolicyCommand) other;
         return personIndex.equals(e.personIndex)
-                && policyIndex.equals(e.policyIndex);
+                && policyName.equals(e.policyName);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/UnassignPolicyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnassignPolicyCommand.java
@@ -33,7 +33,7 @@ public class UnassignPolicyCommand extends Command {
 
     public static final String MESSAGE_UNASSIGN_POLICY_SUCCESS = "Unassigned Policy: %1$s from Person: %2$s";
     public static final String MESSAGE_ALREADY_UNASSIGNED = "Person: %1$s does not have the Policy: %2$s.";
-    public static final String MESSAGE_POLICY_NOT_FOUND = "Policy: %1$s not found in address book.";
+    public static final String MESSAGE_POLICY_NOT_FOUND = "Policy: %1$s not found in list of policies.";
 
 
     private final Index personIndex;
@@ -74,8 +74,6 @@ public class UnassignPolicyCommand extends Command {
         Person assignedPerson = new PersonBuilder(person).removePolicies(policy).build();
 
         model.setPerson(person, assignedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        model.updateFilteredPolicyList(PREDICATE_SHOW_ALL_POLICIES);
         return new CommandResult(String.format(MESSAGE_UNASSIGN_POLICY_SUCCESS,
                 policy.getName(), assignedPerson.getName()));
     }

--- a/src/main/java/seedu/address/logic/commands/UnassignPolicyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnassignPolicyCommand.java
@@ -1,8 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PERSON_INDEX;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_POLICY_INDEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_POLICY;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_POLICIES;
 
@@ -15,6 +14,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 import seedu.address.model.policy.Policy;
+import seedu.address.model.policy.PolicyName;
 
 /**
  * Command to assign a new policy to a person.
@@ -25,46 +25,45 @@ public class UnassignPolicyCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Removes an assigned policy from a person.\n"
             + "Parameters: "
-            + PREFIX_POLICY_INDEX + "POLICY INDEX "
-            + PREFIX_PERSON_INDEX + "PERSON INDEX\n"
+            + "INDEX (must be a positive integer) "
+            + PREFIX_POLICY + "POLICY NAME\n"
             + "Example: "
-            + COMMAND_WORD + " "
-            + PREFIX_POLICY_INDEX + "1 "
-            + PREFIX_PERSON_INDEX + "1";
+            + COMMAND_WORD + " 1 "
+            + PREFIX_POLICY + "health insurance";
 
     public static final String MESSAGE_UNASSIGN_POLICY_SUCCESS = "Unassigned Policy: %1$s from Person: %2$s";
     public static final String MESSAGE_ALREADY_UNASSIGNED = "Person: %1$s does not have the Policy: %2$s.";
+    public static final String MESSAGE_POLICY_NOT_FOUND = "Policy: %1$s not found in address book.";
 
 
-    private final Index policyIndex;
     private final Index personIndex;
+    private final PolicyName policyName;
 
     /**
-     * @param policyIndex Index of the policy to unassign
      * @param personIndex Index of the person to be unassigned
+     * @param policyName Name of the policy to be assigned
      */
-    public UnassignPolicyCommand(Index policyIndex, Index personIndex) {
-        requireNonNull(policyIndex);
+    public UnassignPolicyCommand(Index personIndex, PolicyName policyName) {
         requireNonNull(personIndex);
+        requireNonNull(policyName);
 
-        this.policyIndex = policyIndex;
         this.personIndex = personIndex;
+        this.policyName = policyName;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Person> lastShownPersonList = model.getFilteredPersonList();
-        List<Policy> lastShownPolicyList = model.getFilteredPolicyList();
 
-        if (policyIndex.getZeroBased() >= lastShownPolicyList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_POLICY_DISPLAYED_INDEX);
-        }
         if (personIndex.getZeroBased() >= lastShownPersonList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
+        if (!model.hasPolicyWithName(policyName)) {
+            throw new CommandException(String.format(MESSAGE_POLICY_NOT_FOUND, policyName));
+        }
 
-        Policy policy = lastShownPolicyList.get(policyIndex.getZeroBased());
+        Policy policy = model.getPolicyWithName(policyName);
         Person person = lastShownPersonList.get(personIndex.getZeroBased());
 
         if (!person.hasPolicy(policy)) {
@@ -96,7 +95,7 @@ public class UnassignPolicyCommand extends Command {
         // state check
         UnassignPolicyCommand e = (UnassignPolicyCommand) other;
         return personIndex.equals(e.personIndex)
-                && policyIndex.equals(e.policyIndex);
+                && policyName.equals(e.policyName);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/UnassignPolicyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnassignPolicyCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PERSON_INDEX;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_POLICY_INDEX;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_POLICIES;
 
 import java.util.List;
 
@@ -75,6 +76,7 @@ public class UnassignPolicyCommand extends Command {
 
         model.setPerson(person, assignedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredPolicyList(PREDICATE_SHOW_ALL_POLICIES);
         return new CommandResult(String.format(MESSAGE_UNASSIGN_POLICY_SUCCESS,
                 policy.getName(), assignedPerson.getName()));
     }

--- a/src/main/java/seedu/address/logic/parser/AssignPolicyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AssignPolicyCommandParser.java
@@ -27,20 +27,20 @@ public class AssignPolicyCommandParser implements Parser<AssignPolicyCommand> {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_POLICY);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_POLICY)
-                || !argMultimap.getPreamble().isEmpty()) {
+                || argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AssignPolicyCommand.MESSAGE_USAGE));
         }
 
         Index personIndex;
-        PolicyName policyName;
 
         try {
             personIndex = ParserUtil.parseIndex(argMultimap.getPreamble());
-            policyName = ParserUtil.parsePolicyName(argMultimap.getValue(PREFIX_POLICY).get());
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     AssignPolicyCommand.MESSAGE_USAGE), pe);
         }
+
+        PolicyName policyName = ParserUtil.parsePolicyName(argMultimap.getValue(PREFIX_POLICY).get());
 
         return new AssignPolicyCommand(personIndex, policyName);
     }

--- a/src/main/java/seedu/address/logic/parser/AssignPolicyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AssignPolicyCommandParser.java
@@ -2,14 +2,14 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PERSON_INDEX;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_POLICY_INDEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_POLICY;
 
 import java.util.stream.Stream;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.AssignPolicyCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.policy.PolicyName;
 
 /**
  * Parses input arguments and creates a new AssignPolicyCommand object
@@ -24,25 +24,25 @@ public class AssignPolicyCommandParser implements Parser<AssignPolicyCommand> {
      */
     public AssignPolicyCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_POLICY_INDEX, PREFIX_PERSON_INDEX);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_POLICY);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_POLICY_INDEX, PREFIX_PERSON_INDEX)
+        if (!arePrefixesPresent(argMultimap, PREFIX_POLICY)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AssignPolicyCommand.MESSAGE_USAGE));
         }
 
-        Index personIndex = null;
-        Index policyIndex = null;
+        Index personIndex;
+        PolicyName policyName;
 
         try {
-            policyIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_POLICY_INDEX).get());
-            personIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_PERSON_INDEX).get());
+            personIndex = ParserUtil.parseIndex(argMultimap.getPreamble());
+            policyName = ParserUtil.parsePolicyName(argMultimap.getValue(PREFIX_POLICY).get());
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     AssignPolicyCommand.MESSAGE_USAGE), pe);
         }
 
-        return new AssignPolicyCommand(policyIndex, personIndex);
+        return new AssignPolicyCommand(personIndex, policyName);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -27,9 +27,5 @@ public class CliSyntax {
     public static final Prefix PREFIX_END_AGE = new Prefix("ea/");
     public static final Prefix PREFIX_CRITERIA = new Prefix("cr/");
 
-    // Prefixes for assign/unassign policy commands
-    public static final Prefix PREFIX_POLICY_INDEX = new Prefix("polindex/");
-    public static final Prefix PREFIX_PERSON_INDEX = new Prefix("perindex/");
-
     public static final Prefix PREFIX_MERGE = new Prefix("m/");
 }

--- a/src/main/java/seedu/address/logic/parser/UnassignPolicyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnassignPolicyCommandParser.java
@@ -2,14 +2,14 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PERSON_INDEX;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_POLICY_INDEX;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_POLICY;
 
 import java.util.stream.Stream;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.UnassignPolicyCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.policy.PolicyName;
 
 /**
  * Parses input arguments and creates a new UnassignPolicyCommand object
@@ -24,26 +24,26 @@ public class UnassignPolicyCommandParser implements Parser<UnassignPolicyCommand
      */
     public UnassignPolicyCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_POLICY_INDEX, PREFIX_PERSON_INDEX);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_POLICY);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_POLICY_INDEX, PREFIX_PERSON_INDEX)
+        if (!arePrefixesPresent(argMultimap, PREFIX_POLICY)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     UnassignPolicyCommand.MESSAGE_USAGE));
         }
 
-        Index personIndex = null;
-        Index policyIndex = null;
+        Index personIndex;
+        PolicyName policyName;
 
         try {
-            policyIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_POLICY_INDEX).get());
-            personIndex = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_PERSON_INDEX).get());
+            policyName = ParserUtil.parsePolicyName(argMultimap.getValue(PREFIX_POLICY).get());
+            personIndex = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     UnassignPolicyCommand.MESSAGE_USAGE), pe);
         }
 
-        return new UnassignPolicyCommand(policyIndex, personIndex);
+        return new UnassignPolicyCommand(personIndex, policyName);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/UnassignPolicyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnassignPolicyCommandParser.java
@@ -27,21 +27,21 @@ public class UnassignPolicyCommandParser implements Parser<UnassignPolicyCommand
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_POLICY);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_POLICY)
-                || !argMultimap.getPreamble().isEmpty()) {
+                || argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     UnassignPolicyCommand.MESSAGE_USAGE));
         }
 
         Index personIndex;
-        PolicyName policyName;
 
         try {
-            policyName = ParserUtil.parsePolicyName(argMultimap.getValue(PREFIX_POLICY).get());
             personIndex = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     UnassignPolicyCommand.MESSAGE_USAGE), pe);
         }
+
+        PolicyName policyName = ParserUtil.parsePolicyName(argMultimap.getValue(PREFIX_POLICY).get());
 
         return new UnassignPolicyCommand(personIndex, policyName);
     }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -123,6 +123,9 @@ public class AddressBook implements ReadOnlyAddressBook {
         return policies.contains(policy);
     }
 
+    /**
+     * Returns true if a policy with the same policy name as {@code policyName} exists in the address book.
+     */
     public boolean hasPolicyWithName(PolicyName policyName) {
         requireNonNull(policyName);
         return policies.containsByName(policyName);

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -9,6 +9,7 @@ import javafx.collections.ObservableList;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniquePersonList;
 import seedu.address.model.policy.Policy;
+import seedu.address.model.policy.PolicyName;
 import seedu.address.model.policy.UniquePolicyList;
 
 /**
@@ -122,9 +123,18 @@ public class AddressBook implements ReadOnlyAddressBook {
         return policies.contains(policy);
     }
 
+    public boolean hasPolicyWithName(PolicyName policyName) {
+        requireNonNull(policyName);
+        return policies.containsByName(policyName);
+    }
+
     public Policy getPolicy(Policy policy) {
         requireNonNull(policy);
         return policies.getPolicy(policy);
+    }
+
+    public Policy getPolicyWithName(PolicyName policyName) {
+        return policies.getPolicyWithName(policyName);
     }
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -7,6 +7,7 @@ import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.person.Person;
 import seedu.address.model.policy.Policy;
+import seedu.address.model.policy.PolicyName;
 
 /**
  * The API of the Model component.
@@ -112,9 +113,19 @@ public interface Model {
     boolean hasPolicy(Policy policy);
 
     /**
+     * Returns true if a policy with the same name as {@code policyName} exists in the address book.
+     */
+    boolean hasPolicyWithName(PolicyName policyName);
+
+    /**
      * Returns the matching policy in the address book.
      */
     Policy getPolicy(Policy policy);
+
+    /**
+     * Returns the matching policy with the same {@code policyName} in the address book.
+     */
+    Policy getPolicyWithName(PolicyName policyName);
 
     /**
      * Replaces the given policy {@code target} with {@code editedPolicy}.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -13,6 +13,7 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.person.Person;
 import seedu.address.model.policy.Policy;
+import seedu.address.model.policy.PolicyName;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -128,9 +129,20 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean hasPolicyWithName(PolicyName policyName) {
+        return addressBook.hasPolicyWithName(policyName);
+    }
+
+    @Override
     public Policy getPolicy(Policy policy) {
         requireNonNull(policy);
         return addressBook.getPolicy(policy);
+    }
+
+    @Override
+    public Policy getPolicyWithName(PolicyName policyName) {
+        requireNonNull(policyName);
+        return addressBook.getPolicyWithName(policyName);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/policy/Policy.java
+++ b/src/main/java/seedu/address/model/policy/Policy.java
@@ -127,7 +127,7 @@ public class Policy {
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, description, coverage, price, startAge, endAge, tags);
+        return Objects.hash(name);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/policy/PolicyName.java
+++ b/src/main/java/seedu/address/model/policy/PolicyName.java
@@ -28,7 +28,24 @@ public class PolicyName {
     public PolicyName(String name) {
         requireNonNull(name);
         checkArgument(isValidName(name), MESSAGE_CONSTRAINTS);
-        policyName = name;
+        policyName = formatName(name);
+    }
+
+    /**
+     * Formats the policy name.
+     * @param name name
+     * @return
+     */
+    private String formatName(String name) {
+        String[] nameSplitBySpace = name.toLowerCase().split(" ");
+        StringBuilder formattedName = new StringBuilder();
+        for (int i = 0; i < nameSplitBySpace.length; i++) {
+            String firstLetter = nameSplitBySpace[i].substring(0, 1);
+            String remainingLetters = nameSplitBySpace[i].substring(1);
+            formattedName.append(firstLetter.toUpperCase() + remainingLetters);
+            formattedName.append(" ");
+        }
+        return formattedName.toString().trim();
     }
 
     /**

--- a/src/main/java/seedu/address/model/policy/UniquePolicyList.java
+++ b/src/main/java/seedu/address/model/policy/UniquePolicyList.java
@@ -36,9 +36,25 @@ public class UniquePolicyList implements Iterable<Policy> {
         return internalList.stream().anyMatch(toCheck::isSamePolicy);
     }
 
+    /**
+     * Returns true if the list contains an policy with the same name as {@code policyName}.
+     */
+    public boolean containsByName(PolicyName policyName) {
+        requireNonNull(policyName);
+        return internalList.stream().anyMatch(policy -> policy.getName().equals(policyName));
+    }
+
     public Policy getPolicy(Policy policy) {
         requireNonNull(policy);
         return internalList.stream().filter(policy::isSamePolicy).findAny().get();
+    }
+
+    /**
+     * Gets the policy in the address book with the same name as {@code policyName}
+     */
+    public Policy getPolicyWithName(PolicyName policyName) {
+        requireNonNull(policyName);
+        return internalList.stream().filter(policy -> policy.getName().equals(policyName)).findFirst().get();
     }
 
     /**

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -28,34 +28,42 @@ import seedu.address.model.tag.Tag;
 public class SampleDataUtil {
     public static Person[] getSamplePersons() {
         return new Person[] {
-            new Person(new Name("Alex Yeoh"), new Nric("S000001A"), new Phone("87438807"),
+            new Person(new Name("Alex Yeoh"), new Nric("S0000001A"), new Phone("87438807"),
                     new Email("alexyeoh@example.com"), new Address("Blk 30 Geylang Street 29, #06-40"),
                     new DateOfBirth("12.12.1998"), getPolicySet("teenage"), getTagSet("diabetic")),
-            new Person(new Name("Bernice Yu"), new Nric("S000001B"), new Phone("99272758"),
+            new Person(new Name("Bernice Yu"), new Nric("S0000001B"), new Phone("99272758"),
                     new Email("berniceyu@example.com"), new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
                     new DateOfBirth("11.11.1991"), getPolicySet("young adult", "midlife"),
                     getTagSet("medium priority", "low risk")),
-            new Person(new Name("Charlotte Oliveiro"), new Nric("S000001C"), new Phone("93210283"),
+            new Person(new Name("Charlotte Oliveiro"), new Nric("S0000001C"), new Phone("93210283"),
                     new Email("charlotte@example.com"), new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
                     new DateOfBirth("10.9.2000"), getPolicySet("health"), getTagSet("low priority")),
-            new Person(new Name("David Li"), new Nric("S000001D"), new Phone("91031282"),
+            new Person(new Name("David Li"), new Nric("S0000001D"), new Phone("91031282"),
                     new Email("lidavid@example.com"), new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
                     new DateOfBirth("4.6.1969"), getPolicySet("midlife", "retirement"),
                 getTagSet("high priority")),
-            new Person(new Name("Irfan Ibrahim"), new Nric("S000001F"), new Phone("92492021"),
+            new Person(new Name("Irfan Ibrahim"), new Nric("S0000001F"), new Phone("92492021"),
                     new Email("irfan@example.com"), new Address("Blk 47 Tampines Street 20, #17-35"),
                     new DateOfBirth("09.04.2010"), getPolicySet("school"), getTagSet("smoker")),
-            new Person(new Name("Roy Balakrishnan"), new Nric("S000001G"), new Phone("92624417"),
+            new Person(new Name("Roy Balakrishnan"), new Nric("S0000001G"), new Phone("92624417"),
                     new Email("royb@example.com"), new Address("Blk 45 Aljunied Street 85, #11-31"),
                     new DateOfBirth("23.8.1999"), getPolicySet("car insurance"),
                     getTagSet("low health risk"))
         };
     }
 
+    public static Set<Policy> getSamplePolicies() {
+        return getPolicySet("teenage", "young adult", "midlife", "health", "midlife",
+                "retirement", "school", "car insurance");
+    }
+
     public static ReadOnlyAddressBook getSampleAddressBook() {
         AddressBook sampleAb = new AddressBook();
         for (Person samplePerson : getSamplePersons()) {
             sampleAb.addPerson(samplePerson);
+        }
+        for (Policy samplePolicy : getSamplePolicies()) {
+            sampleAb.addPolicy(samplePolicy);
         }
         return sampleAb;
     }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -24,6 +24,7 @@ import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.person.Person;
 import seedu.address.model.policy.Policy;
+import seedu.address.model.policy.PolicyName;
 
 public class AddCommandTest {
 
@@ -143,6 +144,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public Policy getPolicyWithName(PolicyName policyName) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void setAddressBook(ReadOnlyAddressBook newData) {
             throw new AssertionError("This method should not be called.");
         }
@@ -159,6 +165,11 @@ public class AddCommandTest {
 
         @Override
         public boolean hasPolicy(Policy policy) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasPolicyWithName(PolicyName policyName) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/AddPolicyCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddPolicyCommandTest.java
@@ -23,6 +23,7 @@ import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.person.Person;
 import seedu.address.model.policy.Policy;
+import seedu.address.model.policy.PolicyName;
 
 public class AddPolicyCommandTest {
 
@@ -132,6 +133,11 @@ public class AddPolicyCommandTest {
         }
 
         @Override
+        public Policy getPolicyWithName(PolicyName policyName) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void setAddressBook(ReadOnlyAddressBook newData) {
             throw new AssertionError("This method should not be called.");
         }
@@ -148,6 +154,11 @@ public class AddPolicyCommandTest {
 
         @Override
         public boolean hasPolicy(Policy policy) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasPolicyWithName(PolicyName policyName) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/AssignPolicyCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AssignPolicyCommandTest.java
@@ -64,6 +64,8 @@ class AssignPolicyCommandTest {
                 model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()).getName());
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        showPersonAtIndex(expectedModel, INDEX_FIRST_PERSON);
+        showPolicyAtIndex(expectedModel, INDEX_SECOND_POLICY);
         expectedModel.setPerson(model.getFilteredPersonList().get(0), assignedPerson);
 
         assertCommandSuccess(assignPolicyCommand, model, expectedMessage, expectedModel);

--- a/src/test/java/seedu/address/logic/commands/AssignPolicyCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AssignPolicyCommandTest.java
@@ -1,6 +1,21 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_HEALTH_INSURANCE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_LIFE_INSURANCE;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.logic.commands.CommandTestUtil.showPolicyAtIndex;
+import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_POLICY;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_POLICY;
+
 import org.junit.jupiter.api.Test;
+
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.PersonBuilder;
@@ -12,18 +27,12 @@ import seedu.address.model.person.Person;
 import seedu.address.model.policy.Policy;
 import seedu.address.model.policy.PolicyName;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static seedu.address.logic.commands.CommandTestUtil.*;
-import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
-import static seedu.address.testutil.TypicalIndexes.*;
-
 class AssignPolicyCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
-    public void execute_UnfilteredList_success() {
+    public void execute_unfilteredList_success() {
         Person personToAssign = model.getAddressBook().getPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         Policy policyToAssign = model.getAddressBook().getPolicyList().get(INDEX_SECOND_POLICY.getZeroBased());
         Person assignedPerson = new PersonBuilder(personToAssign).addPolicies(policyToAssign).build();

--- a/src/test/java/seedu/address/logic/commands/AssignPolicyCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AssignPolicyCommandTest.java
@@ -1,0 +1,124 @@
+package seedu.address.logic.commands;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.model.policy.Policy;
+import seedu.address.testutil.PersonBuilder;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static seedu.address.logic.commands.CommandTestUtil.*;
+import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalIndexes.*;
+
+class AssignPolicyCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_filteredList_success() {
+
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        showPolicyAtIndex(model, INDEX_SECOND_POLICY);
+
+        Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Policy policyInFilteredList = model.getFilteredPolicyList().get(INDEX_FIRST_POLICY.getZeroBased());
+        Person assignedPerson = new PersonBuilder(personInFilteredList).withPolicies(policyInFilteredList).build();
+        AssignPolicyCommand assignCommand = new AssignPolicyCommand(INDEX_FIRST_POLICY, INDEX_FIRST_PERSON);
+
+        String expectedMessage = String.format(AssignPolicyCommand.MESSAGE_ASSIGN_POLICY_SUCCESS,
+                model.getFilteredPolicyList().get(INDEX_FIRST_POLICY.getZeroBased()).getName(),
+                model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()).getName());
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(model.getFilteredPersonList().get(0), assignedPerson);
+
+        assertCommandSuccess(assignCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_alreadyAssignedUnfilteredList_failure() {
+        AssignPolicyCommand assignCommand = new AssignPolicyCommand(INDEX_SECOND_POLICY, INDEX_SECOND_PERSON);
+        assertCommandFailure(assignCommand, model, String.format(AssignPolicyCommand.MESSAGE_ALREADY_ASSIGNED,
+                model.getAddressBook().getPersonList().get(INDEX_SECOND_PERSON.getZeroBased()).getName(),
+                model.getAddressBook().getPolicyList().get(INDEX_SECOND_POLICY.getZeroBased()).getName()));
+    }
+
+    @Test
+    public void execute_alreadyAssignedFilteredList_failure() {
+        showPersonAtIndex(model, INDEX_SECOND_PERSON);
+        showPolicyAtIndex(model, INDEX_SECOND_POLICY);
+
+        AssignPolicyCommand assignCommand = new AssignPolicyCommand(INDEX_FIRST_POLICY, INDEX_FIRST_PERSON);
+        assertCommandFailure(assignCommand, model, String.format(AssignPolicyCommand.MESSAGE_ALREADY_ASSIGNED,
+                model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()).getName(),
+                model.getFilteredPolicyList().get(INDEX_FIRST_POLICY.getZeroBased()).getName()));
+    }
+
+    @Test
+    public void execute_invalidPolicyIndexUnfilteredList_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPolicyList().size() + 1);
+        AssignPolicyCommand assignCommand = new AssignPolicyCommand(outOfBoundIndex, INDEX_FIRST_PERSON);
+
+        assertCommandFailure(assignCommand, model, Messages.MESSAGE_INVALID_POLICY_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_invalidPersonIndexUnfilteredList_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        AssignPolicyCommand assignCommand = new AssignPolicyCommand(INDEX_FIRST_POLICY, outOfBoundIndex);
+
+        assertCommandFailure(assignCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    void execute_invalidPersonIndexFilteredList_failure() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+
+        // check if given out of bounds index is still within range for entire list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+
+        AssignPolicyCommand assignCommand = new AssignPolicyCommand(INDEX_FIRST_POLICY, outOfBoundIndex);
+        assertCommandFailure(assignCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    void execute_invalidPolicyIndexFilteredList_failure() {
+        showPolicyAtIndex(model, INDEX_FIRST_POLICY);
+        Index outOfBoundIndex = INDEX_SECOND_POLICY;
+
+        // check if given out of bounds index is still within range for entire list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPolicyList().size());
+
+        AssignPolicyCommand assignCommand = new AssignPolicyCommand(outOfBoundIndex, INDEX_FIRST_PERSON);
+        assertCommandFailure(assignCommand, model, Messages.MESSAGE_INVALID_POLICY_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        final AssignPolicyCommand standardCommand = new AssignPolicyCommand(INDEX_FIRST_POLICY, INDEX_FIRST_PERSON);
+
+        // same value -> returns true
+        AssignPolicyCommand newCommand = new AssignPolicyCommand(INDEX_FIRST_POLICY, INDEX_FIRST_PERSON);
+        assertTrue(standardCommand.equals(newCommand));
+
+        // different values -> returns false
+        newCommand = new AssignPolicyCommand(INDEX_SECOND_POLICY, INDEX_FIRST_PERSON);
+        assertFalse(standardCommand.equals(newCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // different objects -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -43,7 +43,6 @@ public class CommandTestUtil {
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
     public static final String VALID_DATE_OF_BIRTH_AMY = "1.1.1991";
     public static final String VALID_DATE_OF_BIRTH_BOB = "2.2.1992";
-    public static final String VALID_POLICY_HEALTH = "health";
     public static final String VALID_TAG_DIABETIC = "diabetic";
     public static final String VALID_TAG_SMOKER = "smoker";
 
@@ -59,7 +58,6 @@ public class CommandTestUtil {
     public static final String ADDRESS_DESC_BOB = " " + PREFIX_ADDRESS + VALID_ADDRESS_BOB;
     public static final String DATE_OF_BIRTH_DESC_AMY = " " + PREFIX_DATE_OF_BIRTH + VALID_DATE_OF_BIRTH_AMY;
     public static final String DATE_OF_BIRTH_DESC_BOB = " " + PREFIX_DATE_OF_BIRTH + VALID_DATE_OF_BIRTH_BOB;
-    public static final String POLICY_DESC_HEALTH = " " + PREFIX_POLICY + VALID_POLICY_HEALTH;
     public static final String TAG_DESC_DIABETIC = " " + PREFIX_TAG + VALID_TAG_DIABETIC;
     public static final String TAG_DESC_SMOKER = " " + PREFIX_TAG + VALID_TAG_SMOKER;
 
@@ -207,7 +205,7 @@ public class CommandTestUtil {
         assertTrue(targetIndex.getZeroBased() < model.getFilteredPolicyList().size());
 
         Policy policy = model.getFilteredPolicyList().get(targetIndex.getZeroBased());
-        final String[] splitName = policy.getName().toString().split("\\s+");
+        final String[] splitName = policy.getName().policyName.split("\\s+");
         model.updateFilteredPolicyList(new PolicyNameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
 
         assertEquals(1, model.getFilteredPolicyList().size());

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -43,7 +43,8 @@ public class CommandTestUtil {
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
     public static final String VALID_DATE_OF_BIRTH_AMY = "1.1.1991";
     public static final String VALID_DATE_OF_BIRTH_BOB = "2.2.1992";
-    public static final String VALID_POLICY_HEALTH = "health";
+    public static final String VALID_POLICY_HEALTH = "Health Insurance";
+    public static final String VALID_POLICY_LIFE = "Life Insurance";
     public static final String VALID_TAG_DIABETIC = "diabetic";
     public static final String VALID_TAG_SMOKER = "smoker";
 
@@ -60,6 +61,7 @@ public class CommandTestUtil {
     public static final String DATE_OF_BIRTH_DESC_AMY = " " + PREFIX_DATE_OF_BIRTH + VALID_DATE_OF_BIRTH_AMY;
     public static final String DATE_OF_BIRTH_DESC_BOB = " " + PREFIX_DATE_OF_BIRTH + VALID_DATE_OF_BIRTH_BOB;
     public static final String POLICY_DESC_HEALTH = " " + PREFIX_POLICY + VALID_POLICY_HEALTH;
+    public static final String POLICY_DESC_LIFE = " " + PREFIX_POLICY + VALID_POLICY_LIFE;
     public static final String TAG_DESC_DIABETIC = " " + PREFIX_TAG + VALID_TAG_DIABETIC;
     public static final String TAG_DESC_SMOKER = " " + PREFIX_TAG + VALID_TAG_SMOKER;
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -43,6 +43,7 @@ public class CommandTestUtil {
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
     public static final String VALID_DATE_OF_BIRTH_AMY = "1.1.1991";
     public static final String VALID_DATE_OF_BIRTH_BOB = "2.2.1992";
+    public static final String VALID_POLICY_HEALTH = "health";
     public static final String VALID_TAG_DIABETIC = "diabetic";
     public static final String VALID_TAG_SMOKER = "smoker";
 
@@ -58,6 +59,7 @@ public class CommandTestUtil {
     public static final String ADDRESS_DESC_BOB = " " + PREFIX_ADDRESS + VALID_ADDRESS_BOB;
     public static final String DATE_OF_BIRTH_DESC_AMY = " " + PREFIX_DATE_OF_BIRTH + VALID_DATE_OF_BIRTH_AMY;
     public static final String DATE_OF_BIRTH_DESC_BOB = " " + PREFIX_DATE_OF_BIRTH + VALID_DATE_OF_BIRTH_BOB;
+    public static final String POLICY_DESC_HEALTH = " " + PREFIX_POLICY + VALID_POLICY_HEALTH;
     public static final String TAG_DESC_DIABETIC = " " + PREFIX_TAG + VALID_TAG_DIABETIC;
     public static final String TAG_DESC_SMOKER = " " + PREFIX_TAG + VALID_TAG_SMOKER;
 

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -1,6 +1,6 @@
 package seedu.address.logic.commands;
 
-import  static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -1,6 +1,6 @@
 package seedu.address.logic.commands;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import  static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;

--- a/src/test/java/seedu/address/logic/commands/MergeCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MergeCommandTest.java
@@ -25,6 +25,7 @@ import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.policy.Policy;
+import seedu.address.model.policy.PolicyName;
 
 public class MergeCommandTest {
 
@@ -135,6 +136,11 @@ public class MergeCommandTest {
         }
 
         @Override
+        public Policy getPolicyWithName(PolicyName policyName) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void setAddressBook(ReadOnlyAddressBook newData) {
             throw new AssertionError("This method should not be called.");
         }
@@ -151,6 +157,11 @@ public class MergeCommandTest {
 
         @Override
         public boolean hasPolicy(Policy policy) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasPolicyWithName(PolicyName policyName) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/MergeConfirmedCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MergeConfirmedCommandTest.java
@@ -25,6 +25,7 @@ import seedu.address.model.person.Address;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.policy.Policy;
+import seedu.address.model.policy.PolicyName;
 
 public class MergeConfirmedCommandTest {
 
@@ -236,6 +237,11 @@ public class MergeConfirmedCommandTest {
         }
 
         @Override
+        public Policy getPolicyWithName(PolicyName policyName) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void setAddressBook(ReadOnlyAddressBook newData) {
             throw new AssertionError("This method should not be called.");
         }
@@ -252,6 +258,11 @@ public class MergeConfirmedCommandTest {
 
         @Override
         public boolean hasPolicy(Policy policy) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasPolicyWithName(PolicyName policyName) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/MergeRejectedCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MergeRejectedCommandTest.java
@@ -25,6 +25,7 @@ import seedu.address.model.person.Address;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.policy.Policy;
+import seedu.address.model.policy.PolicyName;
 
 public class MergeRejectedCommandTest {
 
@@ -236,6 +237,11 @@ public class MergeRejectedCommandTest {
         }
 
         @Override
+        public Policy getPolicyWithName(PolicyName policyName) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void setAddressBook(ReadOnlyAddressBook newData) {
             throw new AssertionError("This method should not be called.");
         }
@@ -252,6 +258,11 @@ public class MergeRejectedCommandTest {
 
         @Override
         public boolean hasPolicy(Policy policy) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasPolicyWithName(PolicyName policyName) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/UnassignPolicyCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnassignPolicyCommandTest.java
@@ -13,65 +13,67 @@ import seedu.address.model.policy.Policy;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static seedu.address.logic.commands.CommandTestUtil.*;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.*;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
-class AssignPolicyCommandTest {
+class UnassignPolicyCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
     public void execute_UnfilteredList_success() {
-        Person personToAssign = model.getAddressBook().getPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        Policy policyToAssign = model.getAddressBook().getPolicyList().get(INDEX_SECOND_POLICY.getZeroBased());
-        Person assignedPerson = new PersonBuilder(personToAssign).addPolicies(policyToAssign).build();
-        AssignPolicyCommand assignPolicyCommand = new AssignPolicyCommand(INDEX_SECOND_POLICY, INDEX_FIRST_PERSON);
+        Person personToUnassign = model.getAddressBook().getPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Policy policyToUnassign = model.getAddressBook().getPolicyList().get(INDEX_FIRST_POLICY.getZeroBased());
+        Person assignedPerson = new PersonBuilder(personToUnassign).removePolicies(policyToUnassign).build();
+        UnassignPolicyCommand unassignPolicyCommand = new UnassignPolicyCommand(INDEX_FIRST_POLICY, INDEX_FIRST_PERSON);
 
-        String expectedMessage = String.format(AssignPolicyCommand.MESSAGE_ASSIGN_POLICY_SUCCESS,
-                policyToAssign.getName(), personToAssign.getName());
+        String expectedMessage = String.format(UnassignPolicyCommand.MESSAGE_UNASSIGN_POLICY_SUCCESS,
+                policyToUnassign.getName(), personToUnassign.getName());
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(model.getAddressBook().getPersonList().get(INDEX_FIRST_PERSON.getZeroBased()),
                 assignedPerson);
 
-        assertCommandSuccess(assignPolicyCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(unassignPolicyCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_filteredList_success() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        showPolicyAtIndex(model, INDEX_SECOND_POLICY);
+        showPolicyAtIndex(model, INDEX_FIRST_POLICY);
 
         Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         Policy policyInFilteredList = model.getFilteredPolicyList().get(INDEX_FIRST_POLICY.getZeroBased());
-        Person assignedPerson = new PersonBuilder(personInFilteredList).addPolicies(policyInFilteredList).build();
-        AssignPolicyCommand assignPolicyCommand = new AssignPolicyCommand(INDEX_FIRST_POLICY, INDEX_FIRST_PERSON);
+        Person unassignedPerson = new PersonBuilder(personInFilteredList).removePolicies(policyInFilteredList).build();
+        UnassignPolicyCommand unassignPolicyCommand = new UnassignPolicyCommand(INDEX_FIRST_POLICY, INDEX_FIRST_PERSON);
 
-        String expectedMessage = String.format(AssignPolicyCommand.MESSAGE_ASSIGN_POLICY_SUCCESS,
+        String expectedMessage = String.format(UnassignPolicyCommand.MESSAGE_UNASSIGN_POLICY_SUCCESS,
                 model.getFilteredPolicyList().get(INDEX_FIRST_POLICY.getZeroBased()).getName(),
                 model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()).getName());
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setPerson(model.getFilteredPersonList().get(0), assignedPerson);
+        expectedModel.setPerson(model.getFilteredPersonList().get(0), unassignedPerson);
 
-        assertCommandSuccess(assignPolicyCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(unassignPolicyCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
-    public void execute_alreadyAssignedUnfilteredList_failure() {
-        AssignPolicyCommand assignPolicyCommand = new AssignPolicyCommand(INDEX_SECOND_POLICY, INDEX_SECOND_PERSON);
-        assertCommandFailure(assignPolicyCommand, model, String.format(AssignPolicyCommand.MESSAGE_ALREADY_ASSIGNED,
-                model.getAddressBook().getPersonList().get(INDEX_SECOND_PERSON.getZeroBased()).getName(),
+    public void execute_alreadyUnassignedUnfilteredList_failure() {
+        UnassignPolicyCommand unassignPolicyCommand = new UnassignPolicyCommand(INDEX_SECOND_POLICY, INDEX_FIRST_PERSON);
+        assertCommandFailure(unassignPolicyCommand, model, String.format(UnassignPolicyCommand.MESSAGE_ALREADY_UNASSIGNED,
+                model.getAddressBook().getPersonList().get(INDEX_FIRST_PERSON.getZeroBased()).getName(),
                 model.getAddressBook().getPolicyList().get(INDEX_SECOND_POLICY.getZeroBased()).getName()));
     }
 
     @Test
-    public void execute_alreadyAssignedFilteredList_failure() {
-        showPersonAtIndex(model, INDEX_SECOND_PERSON);
+    public void execute_alreadyUnassignedFilteredList_failure() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
         showPolicyAtIndex(model, INDEX_SECOND_POLICY);
 
-        AssignPolicyCommand assignPolicyCommand = new AssignPolicyCommand(INDEX_FIRST_POLICY, INDEX_FIRST_PERSON);
-        assertCommandFailure(assignPolicyCommand, model, String.format(AssignPolicyCommand.MESSAGE_ALREADY_ASSIGNED,
+        UnassignPolicyCommand unassignPolicyCommand = new UnassignPolicyCommand(INDEX_FIRST_POLICY, INDEX_FIRST_PERSON);
+        assertCommandFailure(unassignPolicyCommand, model, String.format(UnassignPolicyCommand.MESSAGE_ALREADY_UNASSIGNED,
                 model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()).getName(),
                 model.getFilteredPolicyList().get(INDEX_FIRST_POLICY.getZeroBased()).getName()));
     }
@@ -79,17 +81,17 @@ class AssignPolicyCommandTest {
     @Test
     public void execute_invalidPolicyIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPolicyList().size() + 1);
-        AssignPolicyCommand assignPolicyCommand = new AssignPolicyCommand(outOfBoundIndex, INDEX_FIRST_PERSON);
+        UnassignPolicyCommand unassignPolicyCommand = new UnassignPolicyCommand(outOfBoundIndex, INDEX_FIRST_PERSON);
 
-        assertCommandFailure(assignPolicyCommand, model, Messages.MESSAGE_INVALID_POLICY_DISPLAYED_INDEX);
+        assertCommandFailure(unassignPolicyCommand, model, Messages.MESSAGE_INVALID_POLICY_DISPLAYED_INDEX);
     }
 
     @Test
     public void execute_invalidPersonIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
-        AssignPolicyCommand assignPolicyCommand = new AssignPolicyCommand(INDEX_FIRST_POLICY, outOfBoundIndex);
+        UnassignPolicyCommand unassignPolicyCommand = new UnassignPolicyCommand(INDEX_FIRST_POLICY, outOfBoundIndex);
 
-        assertCommandFailure(assignPolicyCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(unassignPolicyCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test
@@ -100,8 +102,8 @@ class AssignPolicyCommandTest {
         // check if given out of bounds index is still within range for entire list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
 
-        AssignPolicyCommand assignPolicyCommand = new AssignPolicyCommand(INDEX_FIRST_POLICY, outOfBoundIndex);
-        assertCommandFailure(assignPolicyCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        UnassignPolicyCommand unassignPolicyCommand = new UnassignPolicyCommand(INDEX_FIRST_POLICY, outOfBoundIndex);
+        assertCommandFailure(unassignPolicyCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test
@@ -112,20 +114,20 @@ class AssignPolicyCommandTest {
         // check if given out of bounds index is still within range for entire list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPolicyList().size());
 
-        AssignPolicyCommand assignPolicyCommand = new AssignPolicyCommand(outOfBoundIndex, INDEX_FIRST_PERSON);
-        assertCommandFailure(assignPolicyCommand, model, Messages.MESSAGE_INVALID_POLICY_DISPLAYED_INDEX);
+        UnassignPolicyCommand unassignPolicyCommand = new UnassignPolicyCommand(outOfBoundIndex, INDEX_FIRST_PERSON);
+        assertCommandFailure(unassignPolicyCommand, model, Messages.MESSAGE_INVALID_POLICY_DISPLAYED_INDEX);
     }
 
     @Test
     public void equals() {
-        final AssignPolicyCommand standardCommand = new AssignPolicyCommand(INDEX_FIRST_POLICY, INDEX_FIRST_PERSON);
+        final UnassignPolicyCommand standardCommand = new UnassignPolicyCommand(INDEX_FIRST_POLICY, INDEX_FIRST_PERSON);
 
         // same value -> returns true
-        AssignPolicyCommand newCommand = new AssignPolicyCommand(INDEX_FIRST_POLICY, INDEX_FIRST_PERSON);
+        UnassignPolicyCommand newCommand = new UnassignPolicyCommand(INDEX_FIRST_POLICY, INDEX_FIRST_PERSON);
         assertTrue(standardCommand.equals(newCommand));
 
         // different values -> returns false
-        newCommand = new AssignPolicyCommand(INDEX_SECOND_POLICY, INDEX_FIRST_PERSON);
+        newCommand = new UnassignPolicyCommand(INDEX_SECOND_POLICY, INDEX_FIRST_PERSON);
         assertFalse(standardCommand.equals(newCommand));
 
         // null -> returns false

--- a/src/test/java/seedu/address/logic/commands/UnassignPolicyCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnassignPolicyCommandTest.java
@@ -1,6 +1,19 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_HEALTH_INSURANCE;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.logic.commands.CommandTestUtil.showPolicyAtIndex;
+import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_POLICY;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+
 import org.junit.jupiter.api.Test;
+
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.PersonBuilder;
@@ -12,22 +25,17 @@ import seedu.address.model.person.Person;
 import seedu.address.model.policy.Policy;
 import seedu.address.model.policy.PolicyName;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static seedu.address.logic.commands.CommandTestUtil.*;
-import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
-import static seedu.address.testutil.TypicalIndexes.*;
-
 class UnassignPolicyCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
-    public void execute_UnfilteredList_success() {
+    public void execute_unfilteredList_success() {
         Person personToAssign = model.getAddressBook().getPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         Policy policyToAssign = model.getAddressBook().getPolicyList().get(INDEX_FIRST_POLICY.getZeroBased());
         Person assignedPerson = new PersonBuilder(personToAssign).removePolicies(policyToAssign).build();
-        UnassignPolicyCommand unassignPolicyCommand = new UnassignPolicyCommand(INDEX_FIRST_PERSON, policyToAssign.getName());
+        UnassignPolicyCommand unassignPolicyCommand = new UnassignPolicyCommand(INDEX_FIRST_PERSON,
+                policyToAssign.getName());
 
         String expectedMessage = String.format(UnassignPolicyCommand.MESSAGE_UNASSIGN_POLICY_SUCCESS,
                 policyToAssign.getName(), personToAssign.getName());
@@ -64,7 +72,8 @@ class UnassignPolicyCommandTest {
     public void execute_alreadyAssignedUnfilteredList_failure() {
         final PolicyName policyName = new PolicyName(VALID_NAME_HEALTH_INSURANCE);
         UnassignPolicyCommand unassignPolicyCommand = new UnassignPolicyCommand(INDEX_SECOND_PERSON, policyName);
-        assertCommandFailure(unassignPolicyCommand, model, String.format(UnassignPolicyCommand.MESSAGE_ALREADY_UNASSIGNED,
+        assertCommandFailure(unassignPolicyCommand, model, String.format(
+                UnassignPolicyCommand.MESSAGE_ALREADY_UNASSIGNED,
                 model.getAddressBook().getPersonList().get(INDEX_SECOND_PERSON.getZeroBased()).getName(),
                 policyName));
     }
@@ -75,7 +84,8 @@ class UnassignPolicyCommandTest {
         final PolicyName policyName = new PolicyName(VALID_NAME_HEALTH_INSURANCE);
 
         UnassignPolicyCommand unassignPolicyCommand = new UnassignPolicyCommand(INDEX_FIRST_PERSON, policyName);
-        assertCommandFailure(unassignPolicyCommand, model, String.format(UnassignPolicyCommand.MESSAGE_ALREADY_UNASSIGNED,
+        assertCommandFailure(unassignPolicyCommand, model, String.format(
+                UnassignPolicyCommand.MESSAGE_ALREADY_UNASSIGNED,
                 model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()).getName(), policyName));
     }
 

--- a/src/test/java/seedu/address/logic/commands/UnassignPolicyCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnassignPolicyCommandTest.java
@@ -63,6 +63,8 @@ class UnassignPolicyCommandTest {
                 model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()).getName());
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        showPersonAtIndex(expectedModel, INDEX_FIRST_PERSON);
+        showPolicyAtIndex(expectedModel, INDEX_FIRST_POLICY);
         expectedModel.setPerson(model.getFilteredPersonList().get(0), unassignedPerson);
 
         assertCommandSuccess(unassignPolicyCommand, model, expectedMessage, expectedModel);

--- a/src/test/java/seedu/address/logic/commands/UnassignPolicyCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnassignPolicyCommandTest.java
@@ -10,13 +10,13 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Person;
 import seedu.address.model.policy.Policy;
+import seedu.address.model.policy.PolicyName;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static seedu.address.logic.commands.CommandTestUtil.*;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.*;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 class UnassignPolicyCommandTest {
 
@@ -24,13 +24,13 @@ class UnassignPolicyCommandTest {
 
     @Test
     public void execute_UnfilteredList_success() {
-        Person personToUnassign = model.getAddressBook().getPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        Policy policyToUnassign = model.getAddressBook().getPolicyList().get(INDEX_FIRST_POLICY.getZeroBased());
-        Person assignedPerson = new PersonBuilder(personToUnassign).removePolicies(policyToUnassign).build();
-        UnassignPolicyCommand unassignPolicyCommand = new UnassignPolicyCommand(INDEX_FIRST_POLICY, INDEX_FIRST_PERSON);
+        Person personToAssign = model.getAddressBook().getPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Policy policyToAssign = model.getAddressBook().getPolicyList().get(INDEX_FIRST_POLICY.getZeroBased());
+        Person assignedPerson = new PersonBuilder(personToAssign).removePolicies(policyToAssign).build();
+        UnassignPolicyCommand unassignPolicyCommand = new UnassignPolicyCommand(INDEX_FIRST_PERSON, policyToAssign.getName());
 
         String expectedMessage = String.format(UnassignPolicyCommand.MESSAGE_UNASSIGN_POLICY_SUCCESS,
-                policyToUnassign.getName(), personToUnassign.getName());
+                policyToAssign.getName(), personToAssign.getName());
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(model.getAddressBook().getPersonList().get(INDEX_FIRST_PERSON.getZeroBased()),
@@ -47,7 +47,8 @@ class UnassignPolicyCommandTest {
         Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         Policy policyInFilteredList = model.getFilteredPolicyList().get(INDEX_FIRST_POLICY.getZeroBased());
         Person unassignedPerson = new PersonBuilder(personInFilteredList).removePolicies(policyInFilteredList).build();
-        UnassignPolicyCommand unassignPolicyCommand = new UnassignPolicyCommand(INDEX_FIRST_POLICY, INDEX_FIRST_PERSON);
+        UnassignPolicyCommand unassignPolicyCommand = new UnassignPolicyCommand(INDEX_FIRST_POLICY,
+                policyInFilteredList.getName());
 
         String expectedMessage = String.format(UnassignPolicyCommand.MESSAGE_UNASSIGN_POLICY_SUCCESS,
                 model.getFilteredPolicyList().get(INDEX_FIRST_POLICY.getZeroBased()).getName(),
@@ -60,38 +61,41 @@ class UnassignPolicyCommandTest {
     }
 
     @Test
-    public void execute_alreadyUnassignedUnfilteredList_failure() {
-        UnassignPolicyCommand unassignPolicyCommand = new UnassignPolicyCommand(INDEX_SECOND_POLICY, INDEX_FIRST_PERSON);
+    public void execute_alreadyAssignedUnfilteredList_failure() {
+        final PolicyName policyName = new PolicyName(VALID_NAME_HEALTH_INSURANCE);
+        UnassignPolicyCommand unassignPolicyCommand = new UnassignPolicyCommand(INDEX_SECOND_PERSON, policyName);
         assertCommandFailure(unassignPolicyCommand, model, String.format(UnassignPolicyCommand.MESSAGE_ALREADY_UNASSIGNED,
-                model.getAddressBook().getPersonList().get(INDEX_FIRST_PERSON.getZeroBased()).getName(),
-                model.getAddressBook().getPolicyList().get(INDEX_SECOND_POLICY.getZeroBased()).getName()));
+                model.getAddressBook().getPersonList().get(INDEX_SECOND_PERSON.getZeroBased()).getName(),
+                policyName));
     }
 
     @Test
     public void execute_alreadyUnassignedFilteredList_failure() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        showPolicyAtIndex(model, INDEX_SECOND_POLICY);
+        showPersonAtIndex(model, INDEX_SECOND_PERSON);
+        final PolicyName policyName = new PolicyName(VALID_NAME_HEALTH_INSURANCE);
 
-        UnassignPolicyCommand unassignPolicyCommand = new UnassignPolicyCommand(INDEX_FIRST_POLICY, INDEX_FIRST_PERSON);
+        UnassignPolicyCommand unassignPolicyCommand = new UnassignPolicyCommand(INDEX_FIRST_PERSON, policyName);
         assertCommandFailure(unassignPolicyCommand, model, String.format(UnassignPolicyCommand.MESSAGE_ALREADY_UNASSIGNED,
-                model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()).getName(),
-                model.getFilteredPolicyList().get(INDEX_FIRST_POLICY.getZeroBased()).getName()));
-    }
-
-    @Test
-    public void execute_invalidPolicyIndexUnfilteredList_failure() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPolicyList().size() + 1);
-        UnassignPolicyCommand unassignPolicyCommand = new UnassignPolicyCommand(outOfBoundIndex, INDEX_FIRST_PERSON);
-
-        assertCommandFailure(unassignPolicyCommand, model, Messages.MESSAGE_INVALID_POLICY_DISPLAYED_INDEX);
+                model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()).getName(), policyName));
     }
 
     @Test
     public void execute_invalidPersonIndexUnfilteredList_failure() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
-        UnassignPolicyCommand unassignPolicyCommand = new UnassignPolicyCommand(INDEX_FIRST_POLICY, outOfBoundIndex);
+        UnassignPolicyCommand unassignPolicyCommand = new UnassignPolicyCommand(outOfBoundIndex,
+                new PolicyName(VALID_NAME_HEALTH_INSURANCE));
 
         assertCommandFailure(unassignPolicyCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    void execute_policyNotInAddressBook_failure() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        final PolicyName policyName = new PolicyName("TESTING INVALID POLICY");
+
+        UnassignPolicyCommand unassignPolicyCommand = new UnassignPolicyCommand(INDEX_FIRST_PERSON, policyName);
+        assertCommandFailure(unassignPolicyCommand, model, String.format(UnassignPolicyCommand.MESSAGE_POLICY_NOT_FOUND,
+                policyName));
     }
 
     @Test
@@ -102,32 +106,22 @@ class UnassignPolicyCommandTest {
         // check if given out of bounds index is still within range for entire list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
 
-        UnassignPolicyCommand unassignPolicyCommand = new UnassignPolicyCommand(INDEX_FIRST_POLICY, outOfBoundIndex);
+        UnassignPolicyCommand unassignPolicyCommand = new UnassignPolicyCommand(outOfBoundIndex,
+                new PolicyName(VALID_NAME_HEALTH_INSURANCE));
         assertCommandFailure(unassignPolicyCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test
-    void execute_invalidPolicyIndexFilteredList_failure() {
-        showPolicyAtIndex(model, INDEX_FIRST_POLICY);
-        Index outOfBoundIndex = INDEX_SECOND_POLICY;
-
-        // check if given out of bounds index is still within range for entire list
-        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPolicyList().size());
-
-        UnassignPolicyCommand unassignPolicyCommand = new UnassignPolicyCommand(outOfBoundIndex, INDEX_FIRST_PERSON);
-        assertCommandFailure(unassignPolicyCommand, model, Messages.MESSAGE_INVALID_POLICY_DISPLAYED_INDEX);
-    }
-
-    @Test
     public void equals() {
-        final UnassignPolicyCommand standardCommand = new UnassignPolicyCommand(INDEX_FIRST_POLICY, INDEX_FIRST_PERSON);
+        final PolicyName policyName = new PolicyName(VALID_NAME_HEALTH_INSURANCE);
+        final UnassignPolicyCommand standardCommand = new UnassignPolicyCommand(INDEX_FIRST_PERSON, policyName);
 
         // same value -> returns true
-        UnassignPolicyCommand newCommand = new UnassignPolicyCommand(INDEX_FIRST_POLICY, INDEX_FIRST_PERSON);
+        UnassignPolicyCommand newCommand = new UnassignPolicyCommand(INDEX_FIRST_PERSON, policyName);
         assertTrue(standardCommand.equals(newCommand));
 
         // different values -> returns false
-        newCommand = new UnassignPolicyCommand(INDEX_SECOND_POLICY, INDEX_FIRST_PERSON);
+        newCommand = new UnassignPolicyCommand(INDEX_SECOND_PERSON, policyName);
         assertFalse(standardCommand.equals(newCommand));
 
         // null -> returns false

--- a/src/test/java/seedu/address/logic/parser/AssignPolicyCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AssignPolicyCommandParserTest.java
@@ -1,6 +1,5 @@
 package seedu.address.logic.parser;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_POLICY_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.POLICY_DESC_HEALTH;
@@ -9,7 +8,9 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_LIFE_INSUR
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
 import org.junit.jupiter.api.Test;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.AssignPolicyCommand;
 import seedu.address.model.policy.PolicyName;

--- a/src/test/java/seedu/address/logic/parser/AssignPolicyCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AssignPolicyCommandParserTest.java
@@ -1,0 +1,19 @@
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import org.junit.jupiter.api.Test;
+import seedu.address.logic.commands.AssignPolicyCommand;
+
+class AssignPolicyCommandParserTest {
+
+    private static final String MESSAGE_INVALID_FORMAT =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, AssignPolicyCommand.MESSAGE_USAGE);
+
+    private AssignPolicyCommandParser parser = new AssignPolicyCommandParser();
+
+    @Test
+    void parse_missingParts_failure() {
+        // no
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/UnassignPolicyCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UnassignPolicyCommandParserTest.java
@@ -1,6 +1,5 @@
 package seedu.address.logic.parser;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_POLICY_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.POLICY_DESC_HEALTH;
@@ -9,7 +8,9 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_LIFE_INSUR
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
 import org.junit.jupiter.api.Test;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.UnassignPolicyCommand;
 import seedu.address.model.policy.PolicyName;

--- a/src/test/java/seedu/address/logic/parser/UnassignPolicyCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UnassignPolicyCommandParserTest.java
@@ -11,15 +11,15 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.AssignPolicyCommand;
+import seedu.address.logic.commands.UnassignPolicyCommand;
 import seedu.address.model.policy.PolicyName;
 
-class AssignPolicyCommandParserTest {
+class UnassignPolicyCommandParserTest {
 
     private static final String MESSAGE_INVALID_FORMAT =
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, AssignPolicyCommand.MESSAGE_USAGE);
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnassignPolicyCommand.MESSAGE_USAGE);
 
-    private AssignPolicyCommandParser parser = new AssignPolicyCommandParser();
+    private UnassignPolicyCommandParser parser = new UnassignPolicyCommandParser();
 
     @Test
     public void parse_policyNameSpecified_success() {
@@ -27,7 +27,7 @@ class AssignPolicyCommandParserTest {
         String userInput = targetIndex.getOneBased() + POLICY_DESC_LIFE;
 
         PolicyName policyName = new PolicyName(VALID_NAME_LIFE_INSURANCE);
-        AssignPolicyCommand expectedCommand = new AssignPolicyCommand(targetIndex, policyName);
+        UnassignPolicyCommand expectedCommand = new UnassignPolicyCommand(targetIndex, policyName);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -38,7 +38,7 @@ class AssignPolicyCommandParserTest {
         String userInput = targetIndex.getOneBased() + POLICY_DESC_HEALTH + POLICY_DESC_LIFE;
 
         PolicyName policyName = new PolicyName(VALID_NAME_LIFE_INSURANCE);
-        AssignPolicyCommand expectedCommand = new AssignPolicyCommand(targetIndex, policyName);
+        UnassignPolicyCommand expectedCommand = new UnassignPolicyCommand(targetIndex, policyName);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }

--- a/src/test/java/seedu/address/testutil/TypicalAddressBook.java
+++ b/src/test/java/seedu/address/testutil/TypicalAddressBook.java
@@ -3,8 +3,6 @@ package seedu.address.testutil;
 import static seedu.address.testutil.TypicalPersons.getTypicalPersons;
 import static seedu.address.testutil.TypicalPolicy.getTypicalPolicy;
 
-import java.util.List;
-
 import seedu.address.model.AddressBook;
 import seedu.address.model.person.Person;
 import seedu.address.model.policy.Policy;
@@ -18,8 +16,6 @@ public class TypicalAddressBook {
      */
     public static AddressBook getTypicalAddressBook() {
         AddressBook ab = new AddressBook();
-
-        List<Policy> l = getTypicalPolicy();
 
         for (Person person : getTypicalPersons()) {
             ab.addPerson(person);

--- a/src/test/java/seedu/address/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/address/testutil/TypicalIndexes.java
@@ -9,4 +9,7 @@ public class TypicalIndexes {
     public static final Index INDEX_FIRST_PERSON = Index.fromOneBased(1);
     public static final Index INDEX_SECOND_PERSON = Index.fromOneBased(2);
     public static final Index INDEX_THIRD_PERSON = Index.fromOneBased(3);
+    public static final Index INDEX_FIRST_POLICY = Index.fromOneBased(1);
+    public static final Index INDEX_SECOND_POLICY = Index.fromOneBased(2);
+    public static final Index INDEX_THIRD_POLICY = Index.fromOneBased(3);
 }


### PR DESCRIPTION
Modify `assignpolicy` and `unassignpolicy` commands to use policy name instead of policy index. Also added tests for the two commands and their parsers.