### PR TITLE
Add feature to unassign policies during DOB edits

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -114,6 +114,7 @@ Format: `edit INDEX [n/NAME] [ic/NRIC] [p/PHONE] [e/EMAIL] [a/ADDRESS] [dob/DATE
 * Edits the person at the specified `INDEX`. The index refers to the index number shown in the displayed person list. The index *must be a positive integer* 1, 2, 3, ...
 * At least one of the optional fields must be provided.
 * Existing values will be updated to the input values.
+* If editing a person's date of birth results in him being ineligible for a policy/multiple policies he currently possesses, they will be unassigned from him.
 ****
 
 Examples:

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -139,6 +139,19 @@ public class Person implements Binnable {
     }
 
     /**
+     * Returns a {@code Set<Policy>} of policies that the person owns that he is eligible for.
+     */
+    public Set<Policy> getEligiblePolicies() {
+        HashSet<Policy> eligiblePolicies = new HashSet<>();
+        for (Policy policy : policies) {
+            if (policy.isEligible(this)) {
+                eligiblePolicies.add(policy);
+            }
+        }
+        return eligiblePolicies;
+    }
+
+    /**
      * Returns true if both persons have the same identity and data fields.
      * This defines a stronger notion of equality between two persons.
      */


### PR DESCRIPTION
When editing a person's age, policies that he becomes ineligible for are automatically unassigned.